### PR TITLE
Avoid 'lein bikeshed' warnings.

### DIFF
--- a/src/clojournal/models/article.clj
+++ b/src/clojournal/models/article.clj
@@ -16,17 +16,17 @@
 (defn- fix-article [article]
   (util/fix-object article))
 
-(defn latest-articles [page count]
+(defn latest-articles [page per-page]
   (let [articles (->> (mq/with-collection db "articles"
                         (mq/find {})
                         (mq/sort (array-map :created-at -1))
-                        (mq/skip (* page count))
-                        (mq/limit count))
+                        (mq/skip (* page per-page))
+                        (mq/limit per-page))
                       (map fix-article))
         num (mc/count db "articles")]
     {:articles articles
      :newer-page (when (> page 0) (dec page))
-     :older-page (when (< (* (inc page) count) num) (inc page))}))
+     :older-page (when (< (* (inc page) per-page) num) (inc page))}))
 
 (defn search-articles [words page per-page]
   (let [re (->> words

--- a/src/clojournal/models/tag.clj
+++ b/src/clojournal/models/tag.clj
@@ -10,19 +10,19 @@
 
 (defn all-tags
   ([] (all-tags 20))
-  ([num]
+  ([limit]
    (mq/with-collection db "tags"
      (mq/find {})
      (mq/sort {:refs -1})
-     (mq/limit num))))
+     (mq/limit limit))))
 
 (defn tag-cloud
   ([] (tag-cloud 100))
-  ([num]
+  ([limit]
    (let [tags (mq/with-collection db "tags"
                 (mq/find {})
                 (mq/sort {:_id 1})
-                (mq/limit num))
+                (mq/limit limit))
          refs (map :refs tags)]
      (when (seq refs)
        (let [min (double (apply min refs))


### PR DESCRIPTION
'lein bikeshed' executes some static analysis checks.

```
Checking for arguments colliding with clojure.core functions.
#'clojournal.models.article/latest-articles: 'count' is colliding with a core function
#'clojournal.models.tag/all-tags: 'num' is colliding with a core function
#'clojournal.models.tag/tag-cloud: 'num' is colliding with a core function
```
